### PR TITLE
remove vote function from index page

### DIFF
--- a/app/views/questions/_questions_list.html.erb
+++ b/app/views/questions/_questions_list.html.erb
@@ -7,12 +7,8 @@
           <p>By <%= link_to question.user.username, user_path(question.user.id) %></p>
           <p>Posted on <%= question.formatted_creation_date %> |
           Updated <%= question.formatted_last_updated %></p>
-          <% #TODO: Add # of likes here %>
           <% #TODO: Abstract out query from view! Include? Scope? %>
-          <p>Votes <%= question.votes.count %> | Answers: <%= question.answers.length %></p>
-          <div class="vote-buttons">
-            <%= button_to 'Up' %> <%= button_to 'Down' %>
-          </div>
+          <p>Vote value: <%= question.votes.sum(:value) %> | Answers: <%= question.answers.length %></p>
         </div>
       <% end %>
 </div>


### PR DESCRIPTION
Because it didn't make sense people could vote on a question they couldn't fully see. @maecapozzi @mlefurge @cgrad01 @aklap
